### PR TITLE
 Fixed module export issue

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
-import unusedImports from 'eslint-plugin-unused-imports';
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
-import tsdoc from 'eslint-plugin-tsdoc';
+const unusedImports = require('eslint-plugin-unused-imports');
+const typescriptEslint = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const tsdoc = require('eslint-plugin-tsdoc');
 
-export default [
+module.exports = [
   {
     ignores: ['dist/**', 'node_modules/**', 'eslint.config.js', 'jest.config.js'],
   },
@@ -15,7 +15,7 @@ export default [
       parser: tsParser,
       parserOptions: {
         project: './tsconfig.json',
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir: __dirname,
       },
       globals: {
         window: 'readonly',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@zondax/ledger-filecoin",
   "version": "1.0.0",
-  "type": "module",
   "description": "Node API for the Filecoin App (Ledger Nano S+, X, Stax and Flex)",
   "keywords": [
     "Zondax",


### PR DESCRIPTION
Issue: Package build fails when imported in TypeScript/Next.js projects with error "Export FilecoinApp doesn't exist"
Root Cause: Mismatch between "type": "module" in package.json and CommonJS output from TypeScript compilation
Solution: Remove "type": "module" to align with CommonJS output, enabling both require() and import syntax to work correctly


<!-- ClickUpRef: 869a8qfqe -->
:link: [zboto Link](https://app.clickup.com/t/869a8qfqe)